### PR TITLE
[MD] Fix typo in 'Estailidade'

### DIFF
--- a/src/md/0021-galeshapley.md
+++ b/src/md/0021-galeshapley.md
@@ -68,7 +68,7 @@ $$
 
 :::
 
-### Algoritmo da Estailidade
+### Algoritmo da Estabilidade
 
 Serve para verificar se uma `Lista de Relacionamentos` é estável ou instável.
 


### PR DESCRIPTION
Changed 'Estalidade' to 'Estabilidade'.