### PR TITLE
Fix dark-mode-toggle extra space

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -272,6 +272,7 @@ h2 {
   color: var(--textColor);
   background: none;
   cursor: pointer;
+  font-size: 0;
 }
 
 .anchor.before {


### PR DESCRIPTION
Remove extra space from dark-mode-toggle button.

**Actual:**
![image](https://user-images.githubusercontent.com/50085568/128496301-5c036561-b73b-4b15-9f40-75b19c5bd9f8.png)

**Fixed:**
![image](https://user-images.githubusercontent.com/50085568/128496825-b0c96559-de98-4c6c-97b2-6bea4d13503d.png)
