### PR TITLE
[CDI3] Fix definition for even extension of function

### DIFF
--- a/content/cdi-iii/0010-serie-fourier.md
+++ b/content/cdi-iii/0010-serie-fourier.md
@@ -333,7 +333,7 @@ da sua extensão par a $[-L,L]$, $g(x)$:
 $$
 g(x) = \begin{cases}
 f(x) & \text{se } x \in ]0, L]\\
-0 & \text{se } x = 0\\
+f(0) & \text{se } x = 0\\
 f(-x) & \text{se } x \in [-L, 0[
 \end{cases}
 $$


### PR DESCRIPTION
The value for `x=0` of an even extension is not zero, but the value of the function at `x=0`.