### PR TITLE
[RC] Redundancia de termos na camada de aplicação

### DIFF
--- a/content/rc/0002-aplicacao.md
+++ b/content/rc/0002-aplicacao.md
@@ -77,7 +77,7 @@ antes disso, eis uma breve descrição de cada camada:
   ponto A para o ponto B, não num contexto local mas sim num contexto de uma
   **rede** de computadores e dispositivos de rede. Por exemplo,
   - Como é que consigo comunicar com um _host_ em qualquer ponto na Internet
-    (Protocolo IP - é atribuído um endereço a cada _host_).
+    (IP (Internet Protocol) - é atribuído um endereço a cada _host_).
 - **Transport Layer** - Conjunto de regras que definem como é que o **transporte**
   de dados deve ser feito sobre uma rede de computadores. Por exemplo,
 


### PR DESCRIPTION
IP significa Internet Protocol, assim, utilizar "Protocolo IP" torna-se redundante.

<!--
Obrigado por contribuíres para os Resumos LEIC!

Para garantir consistência, todos os títulos de pull requests devem seguir o formato:
[Sigla da UC] Breve descrição (com a primeira letra maiúscula e sem ponto final)

Exemplos:
[PE] Add variáveis aleatórias
[Fis1] Cleanup cheatsheets
[TC] Add reductions and Teorema de Savitch
[CDI-I] Fix typos

Abaixo podes escrever mais detalhes sobre as tuas alterações, se relevante!
-->
